### PR TITLE
Rename ForceCraft project

### DIFF
--- a/ForceCraft.py
+++ b/ForceCraft.py
@@ -2967,7 +2967,7 @@ class PasswordListGeneratorApp:
 				"cache": {},
 				"timings": {"send": 0, "wait": a.get('latency_ms', 0), "receive": 0}
 			})
-		return {"log": {"version": "1.2", "creator": {"name": "SoupSalad", "version": "1.0"}, "entries": entries}}
+		return {"log": {"version": "1.2", "creator": {"name": "ForceCraft", "version": "1.0"}, "entries": entries}}
 
 	def _screenshot_target(self, url: str, out_path: str) -> None:
 		if not url:

--- a/ForceCraft.pyproj
+++ b/ForceCraft.pyproj
@@ -4,13 +4,13 @@
     <SchemaVersion>2.0</SchemaVersion>
     <ProjectGuid>a80848d4-22b0-43cc-8031-42bf23c3488d</ProjectGuid>
     <ProjectHome>.</ProjectHome>
-    <StartupFile>SoupSalad.py</StartupFile>
+    <StartupFile>ForceCraft.py</StartupFile>
     <SearchPath>
     </SearchPath>
     <WorkingDirectory>.</WorkingDirectory>
     <OutputPath>.</OutputPath>
-    <Name>SoupSalad</Name>
-    <RootNamespace>SoupSalad</RootNamespace>
+    <Name>ForceCraft</Name>
+    <RootNamespace>ForceCraft</RootNamespace>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)' == 'Debug' ">
     <DebugSymbols>true</DebugSymbols>
@@ -21,7 +21,7 @@
     <EnableUnmanagedDebugging>false</EnableUnmanagedDebugging>
   </PropertyGroup>
   <ItemGroup>
-    <Compile Include="SoupSalad.py" />
+    <Compile Include="ForceCraft.py" />
   </ItemGroup>
   <Import Project="$(MSBuildExtensionsPath32)\Microsoft\VisualStudio\v$(VisualStudioVersion)\Python Tools\Microsoft.PythonTools.targets" />
   <!-- Uncomment the CoreCompile target to enable the Build command in

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# SoupSalad
+# ForceCraft
 
 A modernized, GUI-based Password List Generator built with Python. Generate custom password dictionaries from profile data using either character brute-force or realistic smart mutations.
 
@@ -100,14 +100,14 @@ pip install playwright && playwright install chromium
 ## Run
 
 ```bash
-python SoupSalad.py
+python ForceCraft.py
 ```
 
 ## CLI automation
 
 - Multi-target from a file (HTTP/SSH/FTP depending on profile `protocol`):
 ```bash
-python SoupSalad.py \
+python ForceCraft.py \
   --profile myprofile.json \
   --targets-file targets.txt \
   --out-dir ./out \
@@ -118,7 +118,7 @@ python SoupSalad.py \
 
 - Nmap XML import (HTTP/HTTPS extraction):
 ```bash
-python SoupSalad.py \
+python ForceCraft.py \
   --profile http_profile.json \
   --nmap-xml scan.xml \
   --out-dir ./out \
@@ -128,7 +128,7 @@ python SoupSalad.py \
 
 - Single target (headless) with OSCP outputs and DOCX template:
 ```bash
-python SoupSalad.py \
+python ForceCraft.py \
   --profile profiles/oscp-safe-flow.json \
   --out-dir ./bundle \
   --report-md ./bundle/report.md \
@@ -137,7 +137,7 @@ python SoupSalad.py \
   --no-gui
 ```
 
-Environment alternative for template: set `DOCX_TEMPLATE` or `SOUPSALAD_DOCX_TEMPLATE`.
+Environment alternative for template: set `DOCX_TEMPLATE` or `FORCECRAFT_DOCX_TEMPLATE`.
 
 ## Usage (Pentest)
 

--- a/SoupSalad.sln
+++ b/SoupSalad.sln
@@ -1,9 +1,9 @@
-﻿
+
 Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio Version 17
 VisualStudioVersion = 17.6.33712.159
 MinimumVisualStudioVersion = 10.0.40219.1
-Project("{888888A0-9F3D-457C-B088-3A5042F75D52}") = "SoupSalad", "SoupSalad.pyproj", "{A80848D4-22B0-43CC-8031-42BF23C3488D}"
+Project("{888888A0-9F3D-457C-B088-3A5042F75D52}") = "ForceCraft", "ForceCraft.pyproj", "{A80848D4-22B0-43CC-8031-42BF23C3488D}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution


### PR DESCRIPTION
Rename the project from 'SoupSalad' to 'ForceCraft' to align with the user's requested branding.

---
<a href="https://cursor.com/background-agent?bcId=bc-059d176d-cc73-43bc-a88a-5d51073fa8e6">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-059d176d-cc73-43bc-a88a-5d51073fa8e6">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

